### PR TITLE
Remove jquery include in gem's manifest

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,12 @@ Add to your `Gemfile`:
 gem 'administrate-field-hex_color_picker'
 ```
 
+If not already including jQuery in your javascript manifest file, add the following line to `app/assets/javascripts/application.js`:
+
+```javascript
+//= require jquery
+```
+
 Run:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -10,12 +10,6 @@ Add to your `Gemfile`:
 gem 'administrate-field-hex_color_picker'
 ```
 
-If not already including jQuery in your javascript manifest file, add the following line to `app/assets/javascripts/application.js`:
-
-```javascript
-//= require jquery
-```
-
 Run:
 
 ```bash

--- a/app/assets/javascripts/administrate-field-hex_color_picker/application.js
+++ b/app/assets/javascripts/administrate-field-hex_color_picker/application.js
@@ -1,3 +1,2 @@
-//= require jquery
 //= require jquery.minicolors
 //= require_tree


### PR DESCRIPTION
This removes the jQuery require within the Javascript manifest for this field. When jQuery is already required in another manifest within the Rails application, this will cause jQuery to be inlined twice in the development environment and cause jQuery plugins included before it to be broken.